### PR TITLE
Fix Xamarin.Forms renderers

### DIFF
--- a/src/Microsoft.Maui.Graphics.Forms/Microsoft.Maui.Graphics.Forms.csproj
+++ b/src/Microsoft.Maui.Graphics.Forms/Microsoft.Maui.Graphics.Forms.csproj
@@ -2,7 +2,6 @@
     <PropertyGroup>
         <TargetFrameworks>netstandard2.1;netstandard2.0;Xamarin.iOS10;MonoAndroid10.0;Xamarin.Mac20</TargetFrameworks>
         <RootNamespace>Microsoft.Maui.Graphics.Forms</RootNamespace>
-        <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     </PropertyGroup>
     <PropertyGroup>
         <LangVersion>8.0</LangVersion>

--- a/src/Microsoft.Maui.Graphics.Forms/Renderer/GraphicsViewRenderer.Android.cs
+++ b/src/Microsoft.Maui.Graphics.Forms/Renderer/GraphicsViewRenderer.Android.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel;
-using Microsoft.Maui.Graphics.Android;
 using Microsoft.Maui.Graphics.Forms.Android;
+using Microsoft.Maui.Graphics.Native;
 using Android.Content;
 using Xamarin.Forms;
 using Xamarin.Forms.Internals;
@@ -30,6 +30,7 @@ namespace Microsoft.Maui.Graphics.Forms.Android
 			if (e.NewElement != null)
 			{
 				SetNativeControl(new NativeGraphicsView(Context));
+				UpdateDrawable();
 			}
 		}
 

--- a/src/Microsoft.Maui.Graphics.Forms/Renderer/GraphicsViewRenderer.Mac.cs
+++ b/src/Microsoft.Maui.Graphics.Forms/Renderer/GraphicsViewRenderer.Mac.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel;
-using Microsoft.Maui.Graphics.CoreGraphics;
 using Microsoft.Maui.Graphics.Forms;
 using Microsoft.Maui.Graphics.Forms.Mac;
+using Microsoft.Maui.Graphics.Native;
 using Foundation;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.MacOS;
@@ -25,6 +25,7 @@ namespace Microsoft.Maui.Graphics.Forms.Mac
 			if (e.NewElement != null)
 			{
 				SetNativeControl(new NativeGraphicsView());
+				UpdateDrawable();
 			}
 		}
 

--- a/src/Microsoft.Maui.Graphics.Forms/Renderer/GraphicsViewRenderer.iOS.cs
+++ b/src/Microsoft.Maui.Graphics.Forms/Renderer/GraphicsViewRenderer.iOS.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel;
-using Microsoft.Maui.Graphics.CoreGraphics;
 using Microsoft.Maui.Graphics.Forms;
 using Microsoft.Maui.Graphics.Forms.iOS;
+using Microsoft.Maui.Graphics.Native;
 using Foundation;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.iOS;
@@ -25,6 +25,7 @@ namespace Microsoft.Maui.Graphics.Forms.iOS
 			if (e.NewElement != null)
 			{
 				SetNativeControl(new NativeGraphicsView());
+				UpdateDrawable();
 			}
 		}
 


### PR DESCRIPTION
This PR fixes Xamarin.Forms renderers issues:
- platform renderers are not compiled with assembly - `EnableDefaultCompileItems` is `false` and `MultiTargeting.targets` is excluding files
- platform renderers have wrong namespaces, compilation fails
- when `Drawable` is set upon creation, nothing is drawn, `OnElementPropertyChanged` is not called for `Drawable` property 