### PR TITLE
Create CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing
+
+Thank you for your interest in contributing to Maui.Graphics! In this document, we'll outline what you need to know about contributing and how to get started.
+
+## Prerequisites
+
+### Code of Conduct
+
+Please see our [Code of Conduct](CODE-OF-CONDUCT.md).
+
+### Contribution License Agreement
+
+You will need to complete a Contribution License Agreement (CLA) before any pull request can be accepted. Review the CLA at https://cla.dotnetfoundation.org. When you submit a pull request, a CLA assistant bot will confirm you have completed the agreement, or provide you with an opportunity to do so.
+
+## Contributing Code
+
+We are in the beginning phases of building up MAUI, but are still very excited for you to join us during this exciting time :)
+
+### What to work on
+
+Any issue that is not already assigned is up for grabs.
+
+### Style Guide
+
+Follow the style used by the [.NET Foundation](https://github.com/dotnet/runtime/blob/master/docs/coding-guidelines/coding-style.md), with two primary exceptions:
+
+- We avoid using the `private` keyword, as it is the default accessibility level in C#
+- We prefer hard tabs over spaces ([#52](https://github.com/dotnet/Microsoft.Maui.Graphics/pull/52))
+
+### Pull Requests
+
+Please check the "Allow edits from maintainers" checkbox on your pull request. This allows us to quickly make minor fixes and resolve conflicts for you.
+
+### Review Process
+
+All pull requests must be reviewed by at least two members of the .NET MAUI team. We do our best to review pull requests in a timely manner, but please be patient! 
+
+If major changes are requested, the contributor should make them at their earliest convenience or let the reviewers know they are unable to make further contributions.
+
+If only minor changes are required someone else may pick it up and finish it. We will do our best to make sure that all credit is retained for contributors.
+
+## Proposals
+
+Browse the current [issues](https://github.com/dotnet/Microsoft.Maui.Graphics/issues) and [discussions](https://github.com/dotnet/Microsoft.Maui.Graphics/discussions) to see if the topic you have in mind has already been addressed.
+
+To propose a change or new feature, open an issue and prefix the title with `[Enhancement]`.


### PR DESCRIPTION
This PR adds a `CONTRIBUTING.md` to this project (modeled after [dotnet/maui's contributing guide](https://github.com/dotnet/maui/blob/main/.github/CONTRIBUTING.md)). I hope this makes it easier to complete #88 - edit it however you see fit 😄 

* Are all PRs from the public required to be paired with a tagged issue? Consider clarifying this in the "Pull Requests" section.

* It's still a bit unclear whether this project is so early/experimental that contributions from the public are discouraged. Consider clarifying this point in the "Contributing Code" section.