### PR TITLE
Update UWP + Runtime and compile time fixes

### DIFF
--- a/samples/GraphicsTester.WindowsUniversal/GraphicsTester.WindowsUniversal.csproj
+++ b/samples/GraphicsTester.WindowsUniversal/GraphicsTester.WindowsUniversal.csproj
@@ -149,7 +149,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.10</Version>
+      <Version>6.2.13</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">

--- a/src/Microsoft.Maui.Graphics.SharpDX.UWP/Microsoft.Maui.Graphics.SharpDX.UWP.csproj
+++ b/src/Microsoft.Maui.Graphics.SharpDX.UWP/Microsoft.Maui.Graphics.SharpDX.UWP.csproj
@@ -124,7 +124,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.10</Version>
+      <Version>6.2.13</Version>
     </PackageReference>
     <PackageReference Include="SharpDX">
       <Version>4.2.0</Version>

--- a/src/Microsoft.Maui.Graphics.Win2D.UWP/Microsoft.Maui.Graphics.Win2D.UWP.csproj
+++ b/src/Microsoft.Maui.Graphics.Win2D.UWP/Microsoft.Maui.Graphics.Win2D.UWP.csproj
@@ -121,7 +121,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.10</Version>
+      <Version>6.2.13</Version>
     </PackageReference>
     <PackageReference Include="Win2D.uwp">
       <Version>1.25.0</Version>

--- a/src/Microsoft.Maui.Graphics.Xaml.UWP/Microsoft.Maui.Graphics.Xaml.UWP.csproj
+++ b/src/Microsoft.Maui.Graphics.Xaml.UWP/Microsoft.Maui.Graphics.Xaml.UWP.csproj
@@ -120,7 +120,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.10</Version>
+      <Version>6.2.13</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.Maui.Graphics.Xaml.UWP/XamlCanvasState.cs
+++ b/src/Microsoft.Maui.Graphics.Xaml.UWP/XamlCanvasState.cs
@@ -233,7 +233,7 @@ namespace Microsoft.Maui.Graphics.Xaml
 			get
 			{
 				var style = Fonts.CurrentService.GetFontStyleById(_font ?? "Arial");
-				return new global::Windows.UI.Xaml.Media.FontFamily(style.FontFamily.Name);
+				return new global::Windows.UI.Xaml.Media.FontFamily(style != null ? style.FontFamily.Name : "Arial");
 			}
 		}
 

--- a/src/Microsoft.Maui.Graphics.Xaml.WPF/XamlCanvas.cs
+++ b/src/Microsoft.Maui.Graphics.Xaml.WPF/XamlCanvas.cs
@@ -433,8 +433,8 @@ namespace Microsoft.Maui.Graphics.Xaml
 			var item = GetOrCreateItem(ItemType.DrawLine);
 			var element = (Line) item.Element;
 
-			var p1 = CurrentState.Transform.Transform(x1, y1);
-			var p2 = CurrentState.Transform.Transform(x2, y2);
+			var p1 = Vector2.Transform(new Vector2(x1, y1), CurrentState.Transform);
+			var p2 = Vector2.Transform(new Vector2(x2, y2), CurrentState.Transform);
 			element.X1 = p1.X;
 			element.Y1 = p1.Y;
 			element.X2 = p2.X;


### PR DESCRIPTION
- Updated UWP package to the latest version
- Fixed a compilation error in WPF package
- Fixed a runtime crash in UWP

These solutions are applied and tested [HERE](https://github.com/Mohsens22/XamlBenchmark)