### PR TITLE
Software Bill of Materials (SBOM) manifest generation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,6 +6,7 @@ variables:
   provisionator.path: '$(System.DefaultWorkingDirectory)/eng/provisioning/provisioning.csx'
   provisionator.vs: '$(System.DefaultWorkingDirectory)/eng/provisioning/vs.csx'
   provisionator.extraArguments: '--v'
+  signingCondition: and(succeeded(), or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), or(startsWith(variables['Build.SourceBranch'],'refs/tags/'),  startsWith(variables['Build.SourceBranch'],'refs/heads/release/') ))))
 
 parameters:
   - name: BuildConfigurations
@@ -196,4 +197,19 @@ stages:
             signedArtifactName: nuget
             signedArtifactPath: signed
             displayName: Sign Phase
-            condition: and(succeeded(), or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), or(startsWith(variables['Build.SourceBranch'],'refs/tags/'),  startsWith(variables['Build.SourceBranch'],'refs/heads/release/') ))))
+            condition: ${{ variables['signingCondition'] }}
+
+    - stage: sbom
+      displayName: 'Software Bill of Materials'
+      ${{ if not(variables['signingCondition']) }}:
+        dependsOn: [ 'windows' ]
+      ${{ if variables['signingCondition'] }}:
+        dependsOn: [ 'nuget_signing' ]
+      jobs:
+      - template: compliance/sbom/job.v1.yml@internal-templates
+        parameters:
+          artifactNames: ['nuget']
+          ${{ if variables['signingCondition'] }}:
+            artifactMap: ['nuget/signed']
+          packageName: 'Microsoft Maui Graphics'
+          packageFilter: '*.nupkg'


### PR DESCRIPTION
Related work item: VS #[1477663](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1477663)

Per Executive Order (EO) produce a Software Bill of Materials (SBOM) capturing the produced nuget files from a dedicated job
https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/ado-sbom-generator

As a result of this change you will find an artifact named `sbom` attached to each build.  Within that artifact is a `manifest.json` file under a `_manifest` directory capturing all of the packages that constitute the `Software Bill of Materials` 

The `sbom` job captures the nuget package files (*.nupkg) published (uploaded) by the build