### PR TITLE
Store Rect values as LTRB internally

### DIFF
--- a/src/Microsoft.Maui.Graphics/Rect.cs
+++ b/src/Microsoft.Maui.Graphics/Rect.cs
@@ -9,13 +9,13 @@ namespace Microsoft.Maui.Graphics
 	[TypeConverter(typeof(Converters.RectTypeConverter))]
 	public partial struct Rect
 	{
-		public double X { get; set; }
+		public double Left { get; set; }
 
-		public double Y { get; set; }
+		public double Top { get; set; }
 
-		public double Width { get; set; }
+		public double Right { get; set; }
 
-		public double Height { get; set; }
+		public double Bottom { get; set; }
 
 		public static Rect Zero = new Rect();
 
@@ -127,28 +127,28 @@ namespace Microsoft.Maui.Graphics
 		}
 
 		// Position/Size
-		public double Top
+		public double X
 		{
-			get => Y;
-			set => Y = value;
+			get => Left;
+			set => Left = value;
 		}
 
-		public double Bottom
+		public double Y
 		{
-			get => Y + Height;
-			set => Height = value - Y;
+			get => Top;
+			set => Top = value;
 		}
 
-		public double Right
+		public double Width
 		{
-			get => X + Width;
-			set => Width = value - X;
+			get => Right - Left;
+			set => Right = Left + value;
 		}
 
-		public double Left
+		public double Height
 		{
-			get => X;
-			set => X = value;
+			get => Bottom - Top;
+			set => Bottom = Top + value;
 		}
 
 		public bool IsEmpty => (Width <= 0) || (Height <= 0);

--- a/src/Microsoft.Maui.Graphics/RectF.cs
+++ b/src/Microsoft.Maui.Graphics/RectF.cs
@@ -9,13 +9,13 @@ namespace Microsoft.Maui.Graphics
 	[TypeConverter(typeof(Converters.RectFTypeConverter))]
 	public partial struct RectF
 	{
-		public float X { get; set; }
+		public float Left { get; set; }
 
-		public float Y { get; set; }
+		public float Top { get; set; }
 
-		public float Width { get; set; }
+		public float Right { get; set; }
 
-		public float Height { get; set; }
+		public float Bottom { get; set; }
 
 		public static RectF Zero = new RectF();
 
@@ -128,28 +128,28 @@ namespace Microsoft.Maui.Graphics
 		}
 
 		// Position/Size
-		public float Top
+		public float X
 		{
-			get => Y;
-			set => Y = value;
+			get => Left;
+			set => Left = value;
 		}
 
-		public float Bottom
+		public float Y
 		{
-			get => Y + Height;
-			set => Height = value - Y;
+			get => Top;
+			set => Top = value;
 		}
 
-		public float Right
+		public float Width
 		{
-			get => X + Width;
-			set => Width = value - X;
+			get => Right - Left;
+			set => Right = Left + value;
 		}
 
-		public float Left
+		public float Height
 		{
-			get => X;
-			set => X = value;
+			get => Bottom - Top;
+			set => Bottom = Top + value;
 		}
 
 		public bool IsEmpty => (Width <= 0) || (Height <= 0);


### PR DESCRIPTION
As stated in issue #426, the way rectangle properties are stored currently makes it impossible to generate accurate bounding boxes. This pull request changes the internal representation from `X`/`Y`/`Width`/`Height` to `Left`/`Top`/`Right`/`Bottom`. It does not change anything about the interface, just which properties are base properties and which are derived.

There may be a regression in performance for methods that currently use `Width`/`Height` since these are now derived properties.