### PR TITLE
[Windows] Fix DrawImage method

### DIFF
--- a/src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/W2DCanvas.cs
+++ b/src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/W2DCanvas.cs
@@ -510,7 +510,10 @@ After:
 
 		public override void DrawImage(IImage image, float x, float y, float width, float height)
 		{
-			if (image is W2DImage platformImage)
+			var stream = image.AsStream();
+			var imageFromStream = W2DImage.FromStream(stream);
+	
+			if (imageFromStream is W2DImage platformImage)
 			{
 				SetRect(x, y, width, height);
 


### PR DESCRIPTION
Fix `DrawImage `method on Windows

![image](https://user-images.githubusercontent.com/6755973/175083207-923846e5-8ba9-448f-a56f-f32597b0b210.png)
